### PR TITLE
Fix for rotation crash in theme dialog (settings) - tested

### DIFF
--- a/app/src/main/java/ca/rmen/android/scrumchatter/settings/SettingsActivity.java
+++ b/app/src/main/java/ca/rmen/android/scrumchatter/settings/SettingsActivity.java
@@ -41,11 +41,13 @@ public class SettingsActivity extends AppCompatActivity {
         Theme.checkTheme(this);
         ActionBar actionBar = getSupportActionBar();
         if (actionBar != null) actionBar.setDisplayHomeAsUpEnabled(true);
-        GeneralPreferenceFragment fragment = new GeneralPreferenceFragment();
-        getSupportFragmentManager().
-                beginTransaction().
-                replace(android.R.id.content, fragment).
-                commit();
+        if (savedInstanceState == null) {
+            GeneralPreferenceFragment fragment = new GeneralPreferenceFragment();
+            getSupportFragmentManager().
+                    beginTransaction().
+                    replace(android.R.id.content, fragment).
+                    commit();
+        }
         Prefs.getInstance(this).register(mListener);
     }
 


### PR DESCRIPTION
The app used to crash in the theme dialog from the settings activity (see #65)
Fix based on [this solution](https://github.com/Gericop/Android-Support-Preference-V7-Fix/issues/39#issuecomment-241203109)  