### PR TITLE
fix #26 allow adding members that share names with deleted members

### DIFF
--- a/app/src/main/java/ca/rmen/android/scrumchatter/member/list/Members.java
+++ b/app/src/main/java/ca/rmen/android/scrumchatter/member/list/Members.java
@@ -134,17 +134,38 @@ public class Members {
                 mActivity.getString(R.string.dialog_message_delete_member_confirm, member.name), R.id.action_delete_member, extras);
     }
 
+
+
     /**
      * Marks a member as deleted.
      */
     public void deleteMember(final long memberId) {
         Log.v(TAG, "delete member " + memberId);
 
+
+        //get existing user's name
+        String name = "";
+        Cursor existingCursor = mActivity.getContentResolver().query(MemberColumns.CONTENT_URI, new String[] { MemberColumns.NAME },
+                MemberColumns._ID + "=? AND " + MemberColumns.DELETED + "=0", new String[] { String.valueOf(memberId) }, null);
+
+        if (existingCursor != null) {
+            if (existingCursor.moveToFirst()) {
+                name = existingCursor.getString(0) + " ";
+                existingCursor.close();
+            }
+        }
+
+        name += "(deleted)";
+        scheduleUserDelete(memberId, name);
+    }
+
+    private void scheduleUserDelete(final long memberId, final String updatedName){
         // Delete the member in a background thread
         Schedulers.io().scheduleDirect(() -> {
             Uri uri = Uri.withAppendedPath(MemberColumns.CONTENT_URI, String.valueOf(memberId));
             ContentValues values = new ContentValues(1);
             values.put(MemberColumns.DELETED, 1);
+            values.put(MemberColumns.NAME, updatedName);
             mActivity.getContentResolver().update(uri, values, null, null);
         });
     }

--- a/app/src/main/java/ca/rmen/android/scrumchatter/member/list/Members.java
+++ b/app/src/main/java/ca/rmen/android/scrumchatter/member/list/Members.java
@@ -25,6 +25,11 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.support.v4.app.FragmentActivity;
 import android.text.TextUtils;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+
 import ca.rmen.android.scrumchatter.util.Log;
 import ca.rmen.android.scrumchatter.Constants;
 import ca.rmen.android.scrumchatter.R;
@@ -155,7 +160,7 @@ public class Members {
             }
         }
 
-        name += "(deleted)";
+        name += "(deleted: " + new SimpleDateFormat("yyyy-MM-dd", Locale.getDefault()).format(new Date()) + ")";
         scheduleUserDelete(memberId, name);
     }
 

--- a/app/src/main/java/ca/rmen/android/scrumchatter/member/list/Members.java
+++ b/app/src/main/java/ca/rmen/android/scrumchatter/member/list/Members.java
@@ -166,7 +166,7 @@ public class Members {
 
             // Query for a member with this name.
             Cursor existingMemberCountCursor = context.getContentResolver().query(MemberColumns.CONTENT_URI, new String[] { "count(*)" },
-                    MemberColumns.NAME + "=? AND " + MemberColumns.TEAM_ID + "=?", new String[] { String.valueOf(input), String.valueOf(teamId) }, null);
+                    MemberColumns.NAME + "=? AND " + MemberColumns.TEAM_ID + "=? AND " + MemberColumns.DELETED + "=0", new String[] { String.valueOf(input), String.valueOf(teamId) }, null);
 
             // Now Check if the team member exists.
             if (existingMemberCountCursor != null) {


### PR DESCRIPTION
## Description

Made the input validator check only for existing users
Refactored the delete member function, creating a private method for scheduling the deletion.
Added a parameter for updating the name.
Made the delete member function call the schedule function with the updated name.

Deleted users are renamed to "[name] (deleted: YYYY-MM-DD)"

## Screenshots

Bob deleted:
![image](https://github.com/user-attachments/assets/2b47a2ba-d8fd-4c64-a2a7-ddf04038a87d)
New bob joins the team:
![image](https://github.com/user-attachments/assets/e718c6d3-7344-4337-a642-ece8cf306e21)


## Quality checklist
- [x] Self review: I have reviewed this PR myself before opening it for review.
- [X] Tests I have done:
- tested deleting members and re-adding them
- tested adding duplicate members (doesn't work which is correct)
- tested renaming new bobs after previous bob was deleted.
